### PR TITLE
Fix tv show name extraction loop

### DIFF
--- a/app/services/tvShowService.ts
+++ b/app/services/tvShowService.ts
@@ -43,7 +43,8 @@ export async function parseFirstTvShowName(
       return showName;
     } catch (error) {
       console.error("❌ Error parsing TV show name:", error);
-      return null;
+      // Continue with the next magnet link if parsing fails
+      continue;
     }
   }
   


### PR DESCRIPTION
## Summary
- handle TV show parse errors by continuing the loop instead of returning early

## Testing
- `npm run build` *(fails: Failed to fetch fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_6841edfb49ec8328b34e51ec6b9a4c09